### PR TITLE
Fix for absent basepath

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'PHP CodeSniffer Check'
+name: 'PHP_CodeSniffer Check'
 description: 'PHPCS checker with annotations out of the box'
 author: 'Ilya Chekalsky'
 inputs:

--- a/problem-matcher.json
+++ b/problem-matcher.json
@@ -5,7 +5,7 @@
       "severity": "error",
       "pattern": [
         {
-          "regexp": "^<file name=\"(.*)\">$",
+          "regexp": "^<file name=\"(?:\\/github\\/workspace\\/)?(.*)\">$",
           "file": 1
         },
         {


### PR DESCRIPTION
Fixes #2 problem matcher regexp for cases where there is no basepath in phpcs.xml