### PR TITLE
Add ability to check only files that have changed during a PR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM cytopia/phpcs:3
 
+RUN apk add --no-cache jq
+
 COPY entrypoint.sh \
      problem-matcher.json \
      /action/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PHP CodeSniffer GitHub Action
 
-This action will help you to run phpcs (PHP_CodeSniffer) with [GitHub Actions](https://github.com/features/actions) platform. It also supports [annotations](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks#checks) out of the box — you don't need to use any tokens to make it work. 
+This action will help you to run phpcs (PHP_CodeSniffer) with [GitHub Actions](https://github.com/features/actions) platform. It also supports [annotations](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks#checks) out of the box. 
 
 <img src="https://leonardo.osnova.io/491e4ce9-72d9-9417-29f7-9934ce7ec8ad/" alt="How Annotations Works" title="How Annotations Works" width="560" height="432" />
 
@@ -21,6 +21,16 @@ jobs:
         - uses: actions/checkout@v2
         - name: PHPCS check
           uses: chekalsky/phpcs-action@v1
+```
+
+If you want to check only files changed in the PR
+
+```yaml
+        ...
+        - name: PHPCS check
+          uses: chekalsky/phpcs-action@v1
+          with:
+            only_changed_files: true
 ```
 
 Eventually you could also check for warnings.

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,22 @@ inputs:
     description: 'Setting the installed standard paths'
     required: false
     default: ''
+  only_changed_files:
+    description: 'Run linter on changed files only'
+    required: false
+    default: ''
+  token:
+    description: >
+      Personal access token (PAT) used to fetch the repository. The PAT is stored
+      in memory and used to ask the Github API for a list of files changed in
+      the PR.
+
+      We recommend using a service account with the least permissions necessary.
+      Also when generating a new PAT, select the least scopes necessary.
+
+      [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
+    required: false
+    default: ${{ github.token }}
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,18 +4,37 @@ cp /action/problem-matcher.json /github/workflow/problem-matcher.json
 
 echo "::add-matcher::${RUNNER_TEMP}/_github_workflow/problem-matcher.json"
 
+if [ -n "${INPUT_ONLY_CHANGED_FILES}" ] && [ "${INPUT_ONLY_CHANGED_FILES}" = "true" ]; then
+    echo "Will only check changed files"
+    USE_CHANGED_FILES="true"
+    PR="$(jq -r '.pull_request.number' < "${GITHUB_EVENT_PATH}")"
+    URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR}/files"
+    AUTH="Authorization: Bearer ${INPUT_TOKEN}"
+
+    CURL_RESULT=$(curl --request GET --url "${URL}" --header "${AUTH}")
+    CHANGED_FILES=$(echo "${CURL_RESULT}" | jq -r '.[] | select(.status != "removed") | .filename')
+else
+    echo "Will check all files"
+    USE_CHANGED_FILES="false"
+fi
+test $? -ne 0 && echo "Could not determine changed files" && exit 1
+
 if [ -n "${INPUT_INSTALLED_PATHS}" ]; then
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${INPUT_INSTALLED_PATHS}"
 fi
 
 if [ -z "${INPUT_ENABLE_WARNINGS}" ] || [ "${INPUT_ENABLE_WARNINGS}" = "false" ]; then
     echo "Check for warnings disabled"
-
-    ${INPUT_PHPCS_BIN_PATH} -n --report=checkstyle
+    ENABLE_WARNINGS_FLAG="-n"
 else
     echo "Check for warnings enabled"
+    ENABLE_WARNINGS_FLAG=""
+fi
 
-    ${INPUT_PHPCS_BIN_PATH} --report=checkstyle
+if [ "${USE_CHANGED_FILES}" = "true" ]; then
+    echo "${CHANGED_FILES}" | xargs -rt ${INPUT_PHPCS_BIN_PATH} ${ENABLE_WARNINGS_FLAG} --report=checkstyle
+else
+    ${INPUT_PHPCS_BIN_PATH} ${ENABLE_WARNINGS_FLAG} --report=checkstyle
 fi
 
 status=$?


### PR DESCRIPTION
If merged, these changes will limit the scope of phpcs checks to only the files changed in a pull request (limit 3000)

This functionality would be added at the expense of requiring a github token to access the github api to find a list of files changed.  I have tried variations using just the repository and relying on the diff of the merge commit to determine what has changed but have found this method unreliable.

These changes would only work during a PR.  This does not support processing files changed in a single commit